### PR TITLE
The original version produced a broken URL if the application is running at root

### DIFF
--- a/src/RaccoonBlog.Web/Services/MetaWeblog.cs
+++ b/src/RaccoonBlog.Web/Services/MetaWeblog.cs
@@ -183,7 +183,7 @@ namespace RaccoonBlog.Web.Services
         {
             ValidateUser(username, password);
             var imagePhysicalPath = Context.Server.MapPath(ConfigurationManager.AppSettings["uploadsPath"]);
-            var imageWebPath = ConfigurationManager.AppSettings["UploadsPath"].Replace("~", Context.Request.ApplicationPath);
+            var imageWebPath = VirtualPathUtility.ToAbsolute(ConfigurationManager.AppSettings["UploadsPath"]);
 
             imagePhysicalPath = Path.Combine(imagePhysicalPath, mediaObject.name);
             var directoryPath = Path.GetDirectoryName(imagePhysicalPath).Replace("/", "\\");


### PR DESCRIPTION
The original version produced a broken URL if the application is running at root. Using VirtualPathUtility is more robust.
